### PR TITLE
Fix getStartOfWeek not to mutate input date

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -6,9 +6,11 @@ const openingHour = 8
 const closingHour = 21
 
 function getStartOfWeek(date = new Date()) {
-  const day = date.getDay()
-  const diff = date.getDate() - day + (day === 0 ? -6 : 1) // adjust when day is sunday
-  return new Date(date.setDate(diff))
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  d.setDate(diff)
+  return d
 }
 
 export default function Calendar() {


### PR DESCRIPTION
## Summary
- avoid mutating the passed Date in `getStartOfWeek`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856ac873a948333ade853f0dc7cfad1