### PR TITLE
Implement reservation form error state

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,7 @@
   gap: 1rem;
   justify-content: flex-end;
 }
+
+.form-error {
+  color: #f87171;
+}

--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -5,10 +5,12 @@ export default function ReservationForm({ start, onClose, onSaved }) {
   const [name, setName] = useState('')
   const [duration, setDuration] = useState(1)
   const [saving, setSaving] = useState(false)
+  const [formError, setFormError] = useState(null)
 
   const handleSubmit = async e => {
     e.preventDefault()
     setSaving(true)
+    setFormError(null)
     const { error } = await supabase.from('reservations').insert({
       name,
       start: start.toISOString(),
@@ -19,7 +21,7 @@ export default function ReservationForm({ start, onClose, onSaved }) {
       onSaved()
       onClose()
     } else {
-      alert('Erreur lors de la reservation')
+      setFormError('Erreur lors de la reservation')
     }
   }
 
@@ -27,24 +29,27 @@ export default function ReservationForm({ start, onClose, onSaved }) {
     <div className="modal">
       <form onSubmit={handleSubmit} className="form">
         <h3>Réserver le {start.toLocaleString()}</h3>
-        <label>
-          Nom / Lot
-          <input value={name} onChange={e => setName(e.target.value)} required />
-        </label>
-        <label>
-          Durée (h)
-          <input
-            type="number"
-            min="1"
-            max="3"
-            value={duration}
-            onChange={e => setDuration(Number(e.target.value))}
-          />
-        </label>
+        <label htmlFor="name">Nom / Lot</label>
+        <input
+          id="name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          required
+        />
+        <label htmlFor="duration">Durée (h)</label>
+        <input
+          id="duration"
+          type="number"
+          min="1"
+          max="3"
+          value={duration}
+          onChange={e => setDuration(Number(e.target.value))}
+        />
         <div className="actions">
           <button type="submit" disabled={saving}>Réserver</button>
           <button type="button" onClick={onClose}>Annuler</button>
         </div>
+        {formError && <p className="form-error">{formError}</p>}
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- show form submission errors inside `ReservationForm`
- connect labels to inputs with `htmlFor`/`id`
- style the new error message

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856ac7b08648333b5e5df8a624c7cef