### PR TITLE
Add error handling in Calendar fetch

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,8 @@
   gap: 1rem;
   justify-content: flex-end;
 }
+
+.error {
+  color: #f87171;
+  margin-bottom: 1rem;
+}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -14,6 +14,7 @@ function getStartOfWeek(date = new Date()) {
 export default function Calendar() {
   const [reservations, setReservations] = useState([])
   const [selectedSlot, setSelectedSlot] = useState(null)
+  const [errorMsg, setErrorMsg] = useState(null)
 
   const fetchReservations = async () => {
     const { data, error } = await supabase
@@ -21,7 +22,14 @@ export default function Calendar() {
       .select('*')
       .gte('start', getStartOfWeek().toISOString())
       .lte('start', new Date(getStartOfWeek().getTime() + 7 * 24 * 60 * 60 * 1000).toISOString())
-    if (!error) setReservations(data)
+    if (error) {
+      console.error(error.message)
+      // optionally set an error state for UI feedback
+      setErrorMsg('Erreur lors du chargement des réservations')
+      return
+    }
+    setErrorMsg(null)
+    setReservations(data)
   }
 
   useEffect(() => {
@@ -57,6 +65,7 @@ export default function Calendar() {
 
   return (
     <div>
+      {errorMsg && <p className="error">{errorMsg}</p>}
       <table className="calendar">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- handle errors when fetching reservations
- show an error message in the calendar UI
- style `.error` message in CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856ac621ef08333b2f912feb76c645a