### PR TITLE
Fix reservations table fields

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -22,8 +22,13 @@ export default function Calendar() {
     const { data, error } = await supabase
       .from('reservations')
       .select('*')
-      .gte('start', getStartOfWeek().toISOString())
-      .lte('start', new Date(getStartOfWeek().getTime() + 7 * 24 * 60 * 60 * 1000).toISOString())
+      .gte('date', getStartOfWeek().toISOString().split('T')[0])
+      .lte(
+        'date',
+        new Date(getStartOfWeek().getTime() + 7 * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .split('T')[0]
+      )
     if (error) {
       console.error(error.message)
       // optionally set an error state for UI feedback
@@ -31,7 +36,12 @@ export default function Calendar() {
       return
     }
     setErrorMsg(null)
-    setReservations(data)
+    const withDates = data.map(r => ({
+      ...r,
+      start: new Date(`${r.date}T${r.start_time}`),
+      end: new Date(`${r.date}T${r.end_time}`),
+    }))
+    setReservations(withDates)
   }
 
   useEffect(() => {

--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -13,8 +13,12 @@ export default function ReservationForm({ start, onClose, onSaved }) {
     setFormError(null)
     const { error } = await supabase.from('reservations').insert({
       name,
-      start: start.toISOString(),
-      end: new Date(start.getTime() + duration * 60 * 60 * 1000).toISOString(),
+      date: start.toISOString().split('T')[0],
+      start_time: start.toISOString().split('T')[1].slice(0, 8),
+      end_time: new Date(start.getTime() + duration * 60 * 60 * 1000)
+        .toISOString()
+        .split('T')[1]
+        .slice(0, 8),
     })
     setSaving(false)
     if (!error) {


### PR DESCRIPTION
## Summary
- fetch reservation rows by `date` instead of nonexistent `start` column
- translate fetched data into `start`/`end` Date objects for calendar logic
- record new reservations using `date`, `start_time` and `end_time`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856af1c3d208333b0c7a06e385cd6de