### PR TITLE
Fix CET time handling

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -5,6 +5,9 @@ import ReservationForm from './ReservationForm'
 const openingHour = 8
 const closingHour = 21
 
+const pad = n => String(n).padStart(2, '0')
+const formatDate = d => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+
 function getStartOfWeek(date = new Date()) {
   const d = new Date(date)
   const day = d.getDay()
@@ -19,16 +22,13 @@ export default function Calendar() {
   const [errorMsg, setErrorMsg] = useState(null)
 
   const fetchReservations = async () => {
+    const start = getStartOfWeek()
+    const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000)
     const { data, error } = await supabase
       .from('reservations')
       .select('*')
-      .gte('date', getStartOfWeek().toISOString().split('T')[0])
-      .lte(
-        'date',
-        new Date(getStartOfWeek().getTime() + 7 * 24 * 60 * 60 * 1000)
-          .toISOString()
-          .split('T')[0]
-      )
+      .gte('date', formatDate(start))
+      .lte('date', formatDate(end))
     if (error) {
       console.error(error.message)
       // optionally set an error state for UI feedback
@@ -83,7 +83,9 @@ export default function Calendar() {
           <tr>
             <th></th>
             {days.map(d => (
-              <th key={d.toDateString()}>{d.toLocaleDateString()}</th>
+              <th key={d.toDateString()}>
+                {d.toLocaleDateString('fr-FR', { timeZone: 'Europe/Paris' })}
+              </th>
             ))}
           </tr>
         </thead>

--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -1,6 +1,10 @@
 import { useState } from 'react'
 import { supabase } from '../supabaseClient'
 
+const pad = n => String(n).padStart(2, '0')
+const formatDate = d => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+const formatTime = d => `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+
 export default function ReservationForm({ start, onClose, onSaved }) {
   const [name, setName] = useState('')
   const [duration, setDuration] = useState(1)
@@ -13,12 +17,9 @@ export default function ReservationForm({ start, onClose, onSaved }) {
     setFormError(null)
     const { error } = await supabase.from('reservations').insert({
       name,
-      date: start.toISOString().split('T')[0],
-      start_time: start.toISOString().split('T')[1].slice(0, 8),
-      end_time: new Date(start.getTime() + duration * 60 * 60 * 1000)
-        .toISOString()
-        .split('T')[1]
-        .slice(0, 8),
+      date: formatDate(start),
+      start_time: formatTime(start),
+      end_time: formatTime(new Date(start.getTime() + duration * 60 * 60 * 1000)),
     })
     setSaving(false)
     if (!error) {
@@ -32,7 +33,10 @@ export default function ReservationForm({ start, onClose, onSaved }) {
   return (
     <div className="modal">
       <form onSubmit={handleSubmit} className="form">
-        <h3>Réserver le {start.toLocaleString()}</h3>
+        <h3>
+          Réserver le{' '}
+          {start.toLocaleString('fr-FR', { timeZone: 'Europe/Paris' })}
+        </h3>
         <label htmlFor="name">Nom / Lot</label>
         <input
           id="name"


### PR DESCRIPTION
## Summary
- ensure date strings are computed without timezone conversion
- display calendar and form dates using Europe/Paris timezone

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856b0d353688333a9f4fdc1650fbe1a