### PR TITLE
Fix timezone argument order in Calendar handleClick

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -59,7 +59,7 @@ export default function Calendar() {
   }, [])
 
   const handleClick = (day, hour) => {
-    const start = createZonedDate(day, hour, TIME_ZONE)
+    const start = createZonedDate(day, hour, 0, 0, TIME_ZONE)
     setSelectedSlot(start)
   }
 


### PR DESCRIPTION
## Summary
- ensure timezone parameter in `handleClick` is in the correct position

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857c479005c83339ea4b02af70e5bc6