### PR TITLE
Add Supabase OAuth login flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,41 @@
+import { useEffect, useState } from 'react'
 import './App.css'
 import Calendar from './components/Calendar'
+import Login from './components/Login'
+import { supabase } from './supabaseClient'
 
 export default function App() {
+  const [session, setSession] = useState(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
+    })
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+  }
+
   return (
     <div>
       <h1>Réservations</h1>
-      <Calendar />
+      {session ? (
+        <>
+          <button type="button" onClick={handleLogout}>
+            Se déconnecter
+          </button>
+          <Calendar />
+        </>
+      ) : (
+        <Login />
+      )}
     </div>
   )
 }

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,16 @@
+import { supabase } from '../supabaseClient'
+
+export default function Login() {
+  const handleLogin = async () => {
+    await supabase.auth.signInWithOAuth({ provider: 'facebook' })
+  }
+
+  return (
+    <div className="login">
+      <h2>Connexion</h2>
+      <button type="button" onClick={handleLogin}>
+        Se connecter avec Facebook
+      </button>
+    </div>
+  )
+}

--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -16,8 +16,12 @@ export default function ReservationForm({ start, onClose, onSaved }) {
     e.preventDefault()
     setSaving(true)
     setFormError(null)
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
     const { error } = await supabase.from('reservations').insert({
       name,
+      user_id: user?.id,
       date: formatDateInZone(start, TIME_ZONE),
       start_time: formatTimeInZone(start, TIME_ZONE),
       end_time: formatTimeInZone(

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,4 +3,8 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+  },
+})


### PR DESCRIPTION
## Summary
- persist Supabase sessions
- add a Facebook OAuth login page
- show calendar only when logged in and allow logout
- store `user_id` with reservations

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857cb348f1c833398899df1246192d2