### PR TITLE
Add reservation validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Simple reservation calendar using React and Supabase.
 
+New reservations are now created in a **pending** state. Pending slots are shown
+in orange on the calendar. They can be validated from the reservation details
+dialog, turning the slot green.
+
 ```
 # Install dependencies
 npm install

--- a/src/App.css
+++ b/src/App.css
@@ -12,8 +12,11 @@
 .calendar td.free {
   cursor: pointer;
 }
-.calendar td.reserved {
-  background-color: #f87171;
+.calendar td.reserved.pending {
+  background-color: #fb923c;
+}
+.calendar td.reserved.validated {
+  background-color: #4ade80;
 }
 .modal {
   position: fixed;

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -84,6 +84,21 @@ export default function Calendar() {
     fetchReservations()
   }
 
+  const handleValidate = async reservation => {
+    const { error } = await supabase
+      .from('reservations')
+      .update({ status: 'validated' })
+      .eq('id', reservation.id)
+    if (error) {
+      console.error(error.message)
+      setErrorMsg("Erreur lors de la validation")
+      return
+    }
+    setErrorMsg(null)
+    closeReservationDetails()
+    fetchReservations()
+  }
+
   const hours = []
   for (let h = openingHour; h < closingHour; h++) {
     hours.push(h)
@@ -124,7 +139,9 @@ export default function Calendar() {
                 return (
                   <td
                     key={day.toDateString() + hour}
-                    className={reserved ? 'reserved' : 'free'}
+                    className={
+                      reserved ? `reserved ${reserved.status || ''}` : 'free'
+                    }
                     onClick={() =>
                       reserved
                         ? setSelectedReservation(reserved)
@@ -150,6 +167,14 @@ export default function Calendar() {
               {selectedReservation.start.toLocaleString('fr-FR', { timeZone: TIME_ZONE })}
             </p>
             <div className="actions">
+              {selectedReservation.status === 'pending' && (
+                <button
+                  type="button"
+                  onClick={() => handleValidate(selectedReservation)}
+                >
+                  Valider
+                </button>
+              )}
               <button type="button" onClick={() => handleDelete(selectedReservation)}>
                 Annuler
               </button>

--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -24,6 +24,7 @@ export default function ReservationForm({ start, onClose, onSaved }) {
         new Date(start.getTime() + duration * 60 * 60 * 1000),
         TIME_ZONE
       ),
+      status: 'pending',
     })
     setSaving(false)
     if (!error) {


### PR DESCRIPTION
## Summary
- create validation workflow for reservations
- color code on hold and validated slots
- insert pending status for new reservations
- update README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857cfdaf0a88333bfbfabb8960db1fb