### PR TITLE
Improve app styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
     <title>Reservation</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -1,11 +1,18 @@
+.calendar-wrapper {
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+
 .calendar {
   border-collapse: collapse;
   width: 100%;
+  min-width: 600px;
+  background-color: white;
 }
 .calendar th,
 .calendar td {
-  border: 1px solid #ccc;
-  padding: 4px;
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem;
   text-align: center;
   width: 14%;
 }
@@ -13,10 +20,12 @@
   cursor: pointer;
 }
 .calendar td.reserved.pending {
-  background-color: #fb923c;
+  background-color: var(--accent);
+  color: #fff;
 }
 .calendar td.reserved.validated {
-  background-color: #4ade80;
+  background-color: var(--success);
+  color: #fff;
 }
 .modal {
   position: fixed;
@@ -28,15 +37,18 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 1rem;
 }
 .form {
   background: white;
-  color: black;
+  color: var(--fg);
   padding: 1rem;
-  border-radius: 4px;
+  border-radius: 6px;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
+  max-width: 400px;
 }
 .actions {
   display: flex;
@@ -44,11 +56,24 @@
   justify-content: flex-end;
 }
 
+.form input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
 .error {
-  color: #f87171;
+  color: #dc2626;
   margin-bottom: 1rem;
-} 
+}
 
 .form-error {
-  color: #f87171;
+  color: #dc2626;
+}
+
+@media (max-width: 600px) {
+  .calendar th,
+  .calendar td {
+    padding: 0.25rem;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import Calendar from './components/Calendar'
 
 export default function App() {
   return (
-    <div>
+    <div className="app-container">
       <h1>Réservations</h1>
       <Calendar />
     </div>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -119,7 +119,8 @@ export default function Calendar() {
   return (
     <div>
       {errorMsg && <p className="error">{errorMsg}</p>}
-      <table className="calendar">
+      <div className="calendar-wrapper">
+        <table className="calendar">
         <thead>
           <tr>
             <th></th>
@@ -155,7 +156,8 @@ export default function Calendar() {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+      </div>
       {selectedSlot && (
         <ReservationForm start={selectedSlot} onClose={closeForm} onSaved={fetchReservations} />
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,63 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --bg: #f5f5f5;
+  --fg: #1f2937;
+  --primary: #2563eb;
+  --accent: #fb923c;
+  --success: #4ade80;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--primary);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  text-decoration: underline;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
+  background-color: var(--bg);
+  color: var(--fg);
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.app-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 1rem;
 }
 
 h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
+  border-radius: 4px;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--primary);
+  color: white;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  background-color: #1e4fd1;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+
+@media (max-width: 600px) {
+  h1 {
+    font-size: 2rem;
   }
 }


### PR DESCRIPTION
## Summary
- use Google font for nicer typography
- center layout and add wrapper for responsive calendar
- improve calendar, modal, and form styles
- adjust global styles for mobile friendliness

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857d3a9f4c08333aa5674d88ff443fa