### PR TITLE
Add password prompt for reservation validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=<your supabase url>
 VITE_SUPABASE_ANON_KEY=<your anon key>
+VITE_VALIDATION_PASSWORD=<password to validate reservations>

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ npm run dev
 Environment variables required:
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
+- `VITE_VALIDATION_PASSWORD`
 
 Copy `.env.example` to `.env` and fill in the actual values for these keys.

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -7,6 +7,8 @@ import {
   formatDateInZone,
 } from '../utils/dateHelpers'
 
+const VALIDATION_PASSWORD = import.meta.env.VITE_VALIDATION_PASSWORD
+
 const openingHour = 8
 const closingHour = 21
 
@@ -85,6 +87,11 @@ export default function Calendar() {
   }
 
   const handleValidate = async reservation => {
+    const pwd = window.prompt('Mot de passe pour valider :')
+    if (pwd !== VALIDATION_PASSWORD) {
+      setErrorMsg('Mot de passe incorrect')
+      return
+    }
     const { error } = await supabase
       .from('reservations')
       .update({ status: 'validated' })


### PR DESCRIPTION
## Summary
- require password to validate reservations
- document new `VITE_VALIDATION_PASSWORD` variable in README
- add variable to `.env.example`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857e3e951a883339ca146946a28b564