### PR TITLE
Add next week view and limit weekly reservations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -67,6 +67,14 @@
   margin-bottom: 1rem;
 }
 
+.week-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
 .form-error {
   color: #dc2626;
 }

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -50,9 +50,21 @@ function formatTimeInZone(date, timeZone = TIME_ZONE) {
   return `${parts.hour}:${parts.minute}:${parts.second}`
 }
 
+function getStartOfWeek(
+  date = new Date(new Date().toLocaleString('en-US', { timeZone: TIME_ZONE })),
+) {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  d.setDate(diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
 export {
   TIME_ZONE,
   createZonedDate,
   formatDateInZone,
   formatTimeInZone,
+  getStartOfWeek,
 }


### PR DESCRIPTION
## Summary
- add `getStartOfWeek` helper
- limit reservations per user to two per week
- allow calendar navigation between weeks
- show current week range with navigation arrows
- style week navigation section

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857e6c8ecc88333aafbc19788dd1d39