### PR TITLE
Improve calendar navigation and add info

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,11 @@ export default function App() {
   return (
     <div className="app-container">
       <h1>Réservations</h1>
+      <p>
+        Les créneaux apparaissent en orange tant qu&rsquo;ils ne sont pas validés.
+        Utilisez les flèches pour naviguer entre les semaines ; une flèche est
+        désactivée lorsqu&rsquo;aucune autre semaine n&rsquo;est disponible.
+      </p>
       <Calendar />
     </div>
   )

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -13,6 +13,9 @@ const VALIDATION_PASSWORD = import.meta.env.VITE_VALIDATION_PASSWORD
 const openingHour = 8
 const closingHour = 21
 
+const MIN_WEEK_OFFSET = 0
+const MAX_WEEK_OFFSET = 1
+
 const formatDate = d => formatDateInZone(d)
 
 export default function Calendar() {
@@ -20,7 +23,7 @@ export default function Calendar() {
   const [selectedSlot, setSelectedSlot] = useState(null)
   const [selectedReservation, setSelectedReservation] = useState(null)
   const [errorMsg, setErrorMsg] = useState(null)
-  const [weekOffset, setWeekOffset] = useState(0)
+  const [weekOffset, setWeekOffset] = useState(MIN_WEEK_OFFSET)
 
   const fetchReservations = useCallback(async () => {
     const start = getStartOfWeek()
@@ -125,8 +128,8 @@ export default function Calendar() {
       <div className="week-nav">
         <button
           type="button"
-          onClick={() => setWeekOffset(weekOffset - 1)}
-          disabled={weekOffset <= 0}
+          onClick={() => setWeekOffset(Math.max(MIN_WEEK_OFFSET, weekOffset - 1))}
+          disabled={weekOffset <= MIN_WEEK_OFFSET}
         >
           &lt;
         </button>
@@ -136,8 +139,8 @@ export default function Calendar() {
         </span>
         <button
           type="button"
-          onClick={() => setWeekOffset(weekOffset + 1)}
-          disabled={weekOffset >= 1}
+          onClick={() => setWeekOffset(Math.min(MAX_WEEK_OFFSET, weekOffset + 1))}
+          disabled={weekOffset >= MAX_WEEK_OFFSET}
         >
           &gt;
         </button>


### PR DESCRIPTION
## Summary
- show info paragraph above calendar
- prevent going past available weeks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857e8fd282c8333985a6255bcded1af