### PR TITLE
Add express backend with config endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ SMTP_HOST=<smtp host>
 SMTP_PORT=<smtp port>
 SMTP_USER=<smtp user>
 SMTP_PASS=<smtp password>
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ Environment variables required:
 - `SMTP_PORT`
 - `SMTP_USER`
 - `SMTP_PASS`
+- `PORT` (optional, defaults to 3001)
+
+The Node server uses Express to expose an API for sending emails and to provide
+the Supabase configuration values at `/api/config`. It also serves the built
+React application from the `dist` directory when running in production.
 
 Copy `.env.example` to `.env` and fill in the actual values for these keys.
 
-To send notification emails, start the email server in another terminal with:
+To run the server (and enable email notifications), start it with:
 
 ```
 npm run server

--- a/server.js
+++ b/server.js
@@ -3,11 +3,17 @@
 import express from 'express'
 import nodemailer from 'nodemailer'
 import dotenv from 'dotenv'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 dotenv.config()
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
 const app = express()
 app.use(express.json())
+app.use(express.static(path.join(__dirname, 'dist')))
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
@@ -32,6 +38,18 @@ app.post('/api/send-email', async (req, res) => {
     console.error(err)
     res.status(500).json({ error: 'Email send failed' })
   }
+})
+
+app.get('/api/config', (req, res) => {
+  res.json({
+    supabaseUrl: process.env.VITE_SUPABASE_URL,
+    supabaseAnonKey: process.env.VITE_SUPABASE_ANON_KEY,
+    adminEmail: process.env.VITE_ADMIN_EMAIL,
+  })
+})
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'))
 })
 
 const port = process.env.PORT || 3001

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { supabase } from '../supabaseClient'
+import { getSupabase } from '../supabaseClient'
 import { sendEmail } from '../utils/email'
 import ReservationForm from './ReservationForm'
 import {
@@ -27,6 +27,7 @@ export default function Calendar() {
   const [weekOffset, setWeekOffset] = useState(MIN_WEEK_OFFSET)
 
   const fetchReservations = useCallback(async () => {
+    const supabase = await getSupabase()
     const start = getStartOfWeek()
     start.setDate(start.getDate() + weekOffset * 7)
     const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000)
@@ -71,6 +72,7 @@ export default function Calendar() {
 
   const handleDelete = async reservation => {
     if (!window.confirm('Annuler cette réservation ?')) return
+    const supabase = await getSupabase()
     const { error } = await supabase
       .from('reservations')
       .delete()
@@ -102,6 +104,7 @@ export default function Calendar() {
       setErrorMsg('Mot de passe incorrect')
       return
     }
+    const supabase = await getSupabase()
     const { error } = await supabase
       .from('reservations')
       .update({ status: 'validated' })

--- a/src/components/ReservationForm.jsx
+++ b/src/components/ReservationForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { supabase } from '../supabaseClient'
+import { getSupabase } from '../supabaseClient'
 import { sendEmail } from '../utils/email'
 import {
   TIME_ZONE,
@@ -19,6 +19,7 @@ export default function ReservationForm({ start, onClose, onSaved }) {
     e.preventDefault()
     setSaving(true)
     setFormError(null)
+    const supabase = await getSupabase()
     const startWeek = getStartOfWeek(start)
     const endWeek = new Date(startWeek.getTime() + 7 * 24 * 60 * 60 * 1000)
     const { data: existing, error: fetchError } = await supabase

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,6 +1,12 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+let clientPromise
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export async function getSupabase() {
+  if (!clientPromise) {
+    clientPromise = fetch('/api/config')
+      .then(res => res.json())
+      .then(cfg => createClient(cfg.supabaseUrl, cfg.supabaseAnonKey))
+  }
+  return clientPromise
+}


### PR DESCRIPTION
## Summary
- serve the built React app and expose email + config APIs in `server.js`
- fetch Supabase config at runtime via new `/api/config` endpoint
- adjust components to load Supabase client dynamically
- document server usage and add `PORT` placeholder in `.env.example`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857f06982b883338bb765a571538c74